### PR TITLE
feat: allow set `queueOwnerAWSAccountId` for `GetQueueUrl` cross account

### DIFF
--- a/internal/simple_client.go
+++ b/internal/simple_client.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -14,6 +15,22 @@ type Client struct {
 	QueueUrl string
 }
 
+func extractAccountIDFromSQSQueueURL(queueURL string) (string, error) {
+	// Define the regular expression pattern to match the AWS account ID
+	pattern := `https://sqs\.[a-zA-Z0-9-]+\.amazonaws\.com/(\d+)/`
+
+	// Compile the regular expression
+	re := regexp.MustCompile(pattern)
+
+	// Find matches in the queue URL
+	matches := re.FindStringSubmatch(queueURL)
+
+	// The AWS account ID is captured in the first submatch
+	accountId := matches[1]
+
+	return accountId, nil
+}
+
 func NewClient(region, endpoint, queue string) (*Client, error) {
 	sess, err := session.NewSession(aws.NewConfig().WithRegion(region).WithEndpoint(endpoint))
 	if err != nil {
@@ -22,8 +39,11 @@ func NewClient(region, endpoint, queue string) (*Client, error) {
 
 	c := sqs.New(sess)
 
+	queueOwnerAWSAccountId, _ := extractAccountIDFromSQSQueueURL(endpoint)
+
 	output, err := c.GetQueueUrl(&sqs.GetQueueUrlInput{
-		QueueName: aws.String(queue),
+		QueueName:              aws.String(queue),
+		QueueOwnerAWSAccountId: aws.String(queueOwnerAWSAccountId),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("Failed to get url for queue '%s'", queue))


### PR DESCRIPTION
# Current Behavior
Upon initializing a producer (on Account A) to send messages to an SQS owned by another account (Account B), I encounter the error `AWS.SimpleQueueService.NonExistentQueue: The specified queue does not exist for this wsdl version.`

Upon investigation, I discovered that the library still uses Account A's ID to retrieve the queue URL by name, leading to the occurrence of this error.

# Expected Behavior
I expect to extract the `queueOwnerAWSAccountId` from the `queueURL` and incorporate it into the `GetQueueUrl` actions.